### PR TITLE
Reordered instructions for running the basic. Previous version had issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,22 +193,25 @@ Assumes your MiSTer Console port is connected at COM4
 reboot mister
 
 connect to console com4 at 115200 with putty
-login un:root pw:1
+login
+  - un:root
+  - pw:1
+
 load altair core
-
-screen /dev/ttys1 19200
-
-select basic4k32 in osd
-press load program in osd
 select console port in osd
-set sense switches on Altair front panel
 
-- 15 to 10 on
-- 9 off
-- 8 on
+screen /dev/ttyS1 19200
+
+set sense switches on Altair front panel
+  - 15 to 10 on
+  - 9 off
+  - 8 on
 
 select on switch
 select run switch
+
+select basic4k32 in osd
+press load program in osd
 
 MEMORY SIZE?
 TERMINAL WIDTH?

--- a/README.md
+++ b/README.md
@@ -193,11 +193,13 @@ Assumes your MiSTer Console port is connected at COM4
 reboot mister
 
 connect to console com4 at 115200 with putty
+
 login
   - un:root
   - pw:1
 
 load altair core
+
 select console port in osd
 
 screen /dev/ttyS1 19200
@@ -208,9 +210,11 @@ set sense switches on Altair front panel
   - 8 on
 
 select on switch
+
 select run switch
 
 select basic4k32 in osd
+
 press load program in osd
 
 MEMORY SIZE?


### PR DESCRIPTION
Just changes in the doc and update on /dev/ttys1